### PR TITLE
Update NordVPN client, add nickname support, adjust comments, README

### DIFF
--- a/.github/workflows/docker-image-dev.yml
+++ b/.github/workflows/docker-image-dev.yml
@@ -1,4 +1,4 @@
-name: Docker Image CI
+name: Docker Image CI Dev
 
 on:
   push:

--- a/.github/workflows/docker-image-dev.yml
+++ b/.github/workflows/docker-image-dev.yml
@@ -6,9 +6,7 @@ on:
       - 'fs/**'
       - 'Dockerfile'
     branches:
-      - 'master'
-    tags:
-      - v*
+      - 'dev'
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,30 +25,30 @@ jobs:
 
     steps:
       - name: Checkout    
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Docker Meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Build and Push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy-version-d2c25752
+FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy-version-21e99ec9
 LABEL maintainer="Matts Bos - MattsTechInfo"
 
 # Configure the NordVPN client version to install at build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy-version-21e99ec9
+FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy-version-21e99ce9
 LABEL maintainer="Matts Bos - MattsTechInfo"
 
 # Configure the NordVPN client version to install at build

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
 LABEL maintainer="Matts Bos - MattsTechInfo"
 
 # Configure the NordVPN client version to install at build
-ARG NORDVPN_CLIENT_VERSION=3.17.4
+ARG NORDVPN_CLIENT_VERSION=3.18.4
 
 # Avoid interactions during build process
 ARG DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
+FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy-version-d2c25752
 LABEL maintainer="Matts Bos - MattsTechInfo"
 
 # Configure the NordVPN client version to install at build

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A `.env` file is supplied with the `docker-compose.yml` file for configuration p
 - `NORDVPN_MESHNET_DEBUG` - Enable debug mode, anything non-empty will ENABLE. Use this if you need more verbose error logging for troubleshooting.
 - `NORDVPN_HEALTHCHECK_INTERVAL` - Set the interval to verify connectivity to the set URL, defaults to 300 (seconds).
 - `NORDVPN_HEALTHCHECK_URL` - An address to verify if connectivity is available. Choose something depending on what connectivity you want to verify, defaults to www.google.com. Please keep in mind, if the healthcheck fails the container will be killed.
+- `NORDVPN_NICKNAME`- Set a nickname for this device/instance on Meshnet, every peer will see and can use this nickname.
 
 #### Meshnet Permissions
 In this version of NordVPN, permissions must be configured directly on the client. NordVPN currently ALLOWS all peers connected to Meshnet by default for Fileshare and Remote access services and DENIES Routing and Local network services. Configuring peer permissions through the NordVPN account website is still in development and not currently available.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This (Docker) container provides the official NordVPN client configured for Mesh
 > Note: I've created this container for my personal needs, which is to run Meshnet nodes at different locations to be used as outgoing gateways. If you have another use for this container, feel free to let me know or help add functionality if what you are trying to do doesn't work as expected. 
 
 ## General Meshnet information
-Meshnet is a free self hosted VPN network connecting multiple nodes together. It's functionality, provided with the NordVPN application, is available on most platforms, including Android/Google TV. This could potentially make for an excellent Netflix password sharing workaround and viewing your own country's content when abroad, but obviously I would never recommend to do anything against the rules now would I.
+Meshnet is a free self hosted VPN network connecting multiple nodes together. It's functionality, provided with the NordVPN application, is available on most platforms, including Android/Google TV. The usecases are extensive, the most popular ones are to access local data/network through Meshnet while having remote clients or setting up an exit node to route all client traffic through a single location.
 Read more about Meshnet over here: https://meshnet.nordvpn.com/
 
 ## Installation and configuration

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -18,7 +18,7 @@ NORDVPN_NICKNAME=
 # In this version of NordVPN, permissions must be configured directly on the client.
 # Configuring peer permissions through the NordVPN account website is still in development.
 # This container will run DENY configuration first, followed by ALLOW. ALLOW will overwrite the DENY!
-# NordVPN currently ALLOWS all peers connected to Meshnet by default.
+# NordVPN currently ALLOWS all peers connected to Meshnet by default for Fileshare and Remote access services and DENIES Routing and Local network services.
 # Peers must be entered with their FQDN/Name assigned by Meshnet, comma separated.
 
 # DENY peer configuration, comma separated.

--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -11,6 +11,8 @@ NORDVPN_MESHNET_DEBUG=
 NORDVPN_HEALTHCHECK_INTERVAL=300
 # Healthcheck URL to verify if connectivity is up. Replace this with something on your Meshnet (if available), defaults to Google.
 NORDVPN_HEALTHCHECK_URL=www.google.com
+# Set a nickname for this device/instance on Meshnet, every peer will see and can use this nickname.
+NORDVPN_NICKNAME=
 
 # Meshnet permissions
 # In this version of NordVPN, permissions must be configured directly on the client.

--- a/fs/etc/cont-init.d/perms
+++ b/fs/etc/cont-init.d/perms
@@ -5,4 +5,6 @@ chmod +x /usr/bin/nordvpn_login
 chmod +x /usr/bin/meshnet_config
 chmod +x /usr/bin/meshnet_watch
 chmod +x /etc/services.d/nordvpn/data/check
+chmod +x /etc/services.d/nordvpn/run
+chmod +x /etc/services.d/nordvpn/finish
 echo "Executable permissions set."

--- a/fs/usr/bin/meshnet_config
+++ b/fs/usr/bin/meshnet_config
@@ -6,6 +6,11 @@ IFS=','
 # Enable Meshnet, this creates the interface and connects
 nordvpn set meshnet on
 
+# Set nickname of this instance on the Meshnet network
+if [[ -n ${NORDVPN_NICKNAME} ]]; then
+  nordvpn meshnet set nickname ${NORDVPN_NICKNAME}
+fi
+
 # Iterate through Meshnet peer permissions
 if [[ -n ${NORDVPN_DENY_PEER_ROUTING} ]]; then
   read -ra deny_routing <<< "${NORDVPN_DENY_PEER_ROUTING}"

--- a/kubernetes/meshnet-env.yaml
+++ b/kubernetes/meshnet-env.yaml
@@ -17,6 +17,8 @@ data:
   NORDVPN_HEALTHCHECK_INTERVAL: 300
   # Healthcheck URL to verify if connectivity is up. Replace this with something on your Meshnet (if available), defaults to Google.
   NORDVPN_HEALTHCHECK_URL: www.google.com
+  # Set a nickname for this device/instance on Meshnet, every peer will see and can use this nickname.
+  NORDVPN_NICKNAME: ""
 
   # Meshnet permissions
   # In this version of NordVPN, permissions must be configured directly on the client.

--- a/kubernetes/meshnet-env.yaml
+++ b/kubernetes/meshnet-env.yaml
@@ -24,7 +24,7 @@ data:
   # In this version of NordVPN, permissions must be configured directly on the client.
   # Configuring peer permissions through the NordVPN account website is still in development.
   # This container will run DENY configuration first, followed by ALLOW. ALLOW will overwrite the DENY!
-  # NordVPN currently ALLOWS all peers connected to Meshnet by default.
+  # NordVPN currently ALLOWS all peers connected to Meshnet by default for Fileshare and Remote access services and DENIES Routing and Local network services.
   # Peers must be entered with their FQDN/Name assigned by Meshnet, comma separated.
 
   # DENY peer configuration, comma separated.


### PR DESCRIPTION
Update NordVPN client to 3.18.4
Added functionality to set the nickname with NORDVPN_NICKNAME.
Updated the README and .env comments.
Lock prebuilt Ubuntu version, newer version currently have permission issues.
Split up dev and master CI to support builds from adjusted dev CI.
